### PR TITLE
Add perfil page with session validation and tabs

### DIFF
--- a/alquiler_vehiculos/cliente/perfil.php
+++ b/alquiler_vehiculos/cliente/perfil.php
@@ -1,3 +1,47 @@
 <?php
-// Placeholder for perfil.php
+session_start();
+
+if (!isset($_SESSION['id_cliente']) || ($_SESSION['rol'] ?? '') !== 'cliente') {
+    header('Location: /login.php');
+    exit;
+}
+
+require_once '../includes/header.php';
+require_once '../includes/nav_cliente.php';
+
+?>
+
+<div class="container mt-4">
+    <ul class="nav nav-tabs" id="perfilTabs" role="tablist">
+        <li class="nav-item" role="presentation">
+            <button class="nav-link active" id="datos-tab" data-bs-toggle="tab" data-bs-target="#datos" type="button" role="tab" aria-controls="datos" aria-selected="true">
+                Mis datos
+            </button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link" id="pagos-tab" data-bs-toggle="tab" data-bs-target="#pagos" type="button" role="tab" aria-controls="pagos" aria-selected="false">
+                Pagos y facturas
+            </button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link" id="alquileres-tab" data-bs-toggle="tab" data-bs-target="#alquileres" type="button" role="tab" aria-controls="alquileres" aria-selected="false">
+                Mis alquileres
+            </button>
+        </li>
+    </ul>
+    <div class="tab-content" id="perfilTabsContent">
+        <div class="tab-pane fade show active" id="datos" role="tabpanel" aria-labelledby="datos-tab">
+            <?php include 'secciones/mis_datos.php'; ?>
+        </div>
+        <div class="tab-pane fade" id="pagos" role="tabpanel" aria-labelledby="pagos-tab">
+            <?php include 'secciones/pagos_facturas.php'; ?>
+        </div>
+        <div class="tab-pane fade" id="alquileres" role="tabpanel" aria-labelledby="alquileres-tab">
+            <?php include 'secciones/mis_alquileres.php'; ?>
+        </div>
+    </div>
+</div>
+
+<?php
+require_once '../includes/footer.php';
 


### PR DESCRIPTION
## Summary
- implement `/cliente/perfil.php` with a session check and bootstrap tab layout

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b29319cec832b8260c886ea856907