### PR TITLE
Fix license queries

### DIFF
--- a/alquiler_vehiculos/cliente/secciones/mis_datos.php
+++ b/alquiler_vehiculos/cliente/secciones/mis_datos.php
@@ -15,7 +15,7 @@ if ($idCliente) {
     $cliente = $stmt->fetch();
 
     // Datos de la licencia y su categoría
-    $licenciaQuery = 'SELECT l.numero, l.fecha_expedicion, l.fecha_vencimiento, c.nombre_categoria FROM licencia l LEFT JOIN categoria c ON c.id_licencia = l.id WHERE l.Id_usuario = ?';
+    $licenciaQuery = 'SELECT l.numero, l.fecha_expedicion, l.fecha_vencimiento,  c.nombre_categoria FROM licencia l LEFT JOIN categoria c ON c.id_licencia = l.id WHERE l.id_usuario = ?';
     $stmt = $pdo->prepare($licenciaQuery);
     $stmt->execute([$idCliente]);
     $licencia = $stmt->fetch();

--- a/alquiler_vehiculos/controladores/actualizar_licencia.php
+++ b/alquiler_vehiculos/controladores/actualizar_licencia.php
@@ -39,15 +39,4 @@ try {
     header('Location: /cliente/perfil.php?error=Error%20al%20actualizar%20la%20licencia');
     exit;
 }
-?>
-require_once '../includes/csrf.php';
 
-// Validar el token CSRF antes de procesar los datos del formulario
-if (!validarToken($_POST['csrf_token'] ?? '')) {
-    header('Location: /cliente/perfil.php?error=Token CSRF inválido');
-    exit;
-}
-
-// Lógica de actualización (placeholder)
-
-header('Location: /cliente/perfil.php?exito=Licencia actualizada');


### PR DESCRIPTION
## Summary
- clean up leftover code in `actualizar_licencia.php`
- fix column name casing when selecting license info

## Testing
- `php -l alquiler_vehiculos/cliente/secciones/mis_datos.php`
- `php -l alquiler_vehiculos/controladores/actualizar_licencia.php`


------
https://chatgpt.com/codex/tasks/task_e_686b34993018832bb3a2526437567875