### PR TITLE
Implement PDO connection class

### DIFF
--- a/alquiler_vehiculos/cliente/secciones/mis_datos.php
+++ b/alquiler_vehiculos/cliente/secciones/mis_datos.php
@@ -5,6 +5,9 @@ $idCliente = $_SESSION['id_cliente'] ?? null;
 require_once '../../modelos/conexion.php';
 require_once '../../includes/csrf.php';
 
+// Obtener instancia de PDO
+$pdo = Conexion::getPDO();
+
 $cliente = [];
 $licencia = [];
 

--- a/alquiler_vehiculos/controladores/actualizar_licencia.php
+++ b/alquiler_vehiculos/controladores/actualizar_licencia.php
@@ -4,6 +4,9 @@ session_start();
 require_once '../modelos/conexion.php';
 require_once '../includes/csrf.php';
 
+// Instanciar conexión
+$pdo = Conexion::getPDO();
+
 if (!isset($_SESSION['id_cliente']) || !validarToken($_POST['csrf_token'] ?? '')) {
     header('Location: /cliente/perfil.php?error=Acceso%20no%20autorizado');
     exit;

--- a/alquiler_vehiculos/modelos/conexion.php
+++ b/alquiler_vehiculos/modelos/conexion.php
@@ -1,17 +1,55 @@
 <?php
-$host = 'localhost';
-$db   = 'alquiler_vehiculos';
-$user = 'root';
-$pass = '';
-$charset = 'utf8mb4';
-$dsn = "mysql:host=$host;dbname=$db;charset=$charset";
-$options = [
-    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
-    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-];
-try {
-    $pdo = new PDO($dsn, $user, $pass, $options);
-} catch (PDOException $e) {
-    die('Error de conexión: ' . $e->getMessage());
+/**
+ * Manejador de conexión a la base de datos.
+ *
+ * Este archivo expone una clase sencilla con un método estático para obtener
+ * una instancia de PDO. Otros scripts pueden incluir este archivo y llamar a
+ * `Conexion::getPDO()` para ejecutar consultas de manera segura.
+ */
+
+class Conexion
+{
+    /** @var string Datos de conexión */
+    private static string $host = 'localhost';
+    private static string $db   = 'alquiler_vehiculos';
+    private static string $user = 'root';
+    private static string $pass = '';
+    private static string $charset = 'utf8mb4';
+
+    /** @var PDO|null Instancia de PDO reutilizable */
+    private static ?PDO $pdo = null;
+
+    /**
+     * Devuelve una instancia de PDO inicializada.
+     *
+     * @throws PDOException Si la conexión falla.
+     */
+    public static function getPDO(): PDO
+    {
+        if (self::$pdo === null) {
+            $dsn = sprintf(
+                'mysql:host=%s;dbname=%s;charset=%s',
+                self::$host,
+                self::$db,
+                self::$charset
+            );
+
+            $options = [
+                PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            ];
+
+            try {
+                self::$pdo = new PDO($dsn, self::$user, self::$pass, $options);
+            } catch (PDOException $e) {
+                // Se relanza la excepción para que el script llamador pueda
+                // gestionarla según corresponda.
+                throw new PDOException('Error de conexión: ' . $e->getMessage(), (int) $e->getCode());
+            }
+        }
+
+        return self::$pdo;
+    }
 }
+
 ?>


### PR DESCRIPTION
## Summary
- introduce `Conexion` class for reusable PDO connection
- use `Conexion::getPDO()` in `mis_datos.php` and `actualizar_licencia.php`

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b35a43208832ba897f4048642d3cc