### PR TITLE
Fix CSRF helper

### DIFF
--- a/alquiler_vehiculos/includes/csrf.php
+++ b/alquiler_vehiculos/includes/csrf.php
@@ -1,16 +1,6 @@
 <?php
+
 function generarToken(): string {
-    if (empty($_SESSION['csrf_token'])) {
-        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
-    }
-    return $_SESSION['csrf_token'];
-}
-
-function validarToken(string $token): bool {
-/* Funciones de utilidad para proteger formularios con tokens CSRF.
- */
-
-function generarToken() {
     if (session_status() !== PHP_SESSION_ACTIVE) {
         session_start();
     }
@@ -22,11 +12,12 @@ function generarToken() {
     return $_SESSION['csrf_token'];
 }
 
-function validarToken($token) {
+function validarToken(string $token): bool {
     if (session_status() !== PHP_SESSION_ACTIVE) {
         session_start();
     }
 
     return isset($_SESSION['csrf_token']) && hash_equals($_SESSION['csrf_token'], $token);
 }
+
 ?>


### PR DESCRIPTION
## Summary
- clean up csrf helper functions
- ensure sessions are started when inactive

## Testing
- `php -l alquiler_vehiculos/includes/csrf.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b379ab2f8832bb8a5e4798704bd90