### PR TITLE
Agregar controlador de pagos

### DIFF
--- a/alquiler_vehiculos/controladores/realizar_pago.php
+++ b/alquiler_vehiculos/controladores/realizar_pago.php
@@ -1,3 +1,67 @@
 <?php
-// Placeholder for realizar_pago.php
+session_start();
 
+require_once '../modelos/conexion.php';
+require_once '../includes/csrf.php';
+
+// Verificar sesion y token CSRF
+if (!isset($_SESSION['id_cliente']) ||
+    ($_SESSION['rol'] ?? '') !== 'cliente' ||
+    !validarToken($_POST['csrf_token'] ?? '')) {
+    header('Location: /cliente/perfil.php?error=Acceso%20no%20autorizado');
+    exit;
+}
+
+$idCliente   = $_SESSION['id_cliente'];
+$idAbono     = (int) ($_POST['id_abono'] ?? 0);
+$idMedioPago = (int) ($_POST['id_medio_pago'] ?? 0);
+
+if ($idAbono <= 0 || $idMedioPago <= 0) {
+    header('Location: /cliente/perfil.php?error=Datos%20no%20validos');
+    exit;
+}
+
+$pdo = Conexion::getPDO();
+
+// Comprobar que el abono pertenece al cliente
+$abonoStmt = $pdo->prepare('SELECT id FROM abono WHERE id = ? AND id_cliente = ?');
+$abonoStmt->execute([$idAbono, $idCliente]);
+$abono = $abonoStmt->fetch();
+
+if (!$abono) {
+    header('Location: /cliente/perfil.php?error=Abono%20invalido');
+    exit;
+}
+
+// Comprobar que el medio de pago pertenece al cliente
+$medioStmt = $pdo->prepare('SELECT id FROM medio_pago WHERE id = ? AND id_cliente = ?');
+$medioStmt->execute([$idMedioPago, $idCliente]);
+$medio = $medioStmt->fetch();
+
+if (!$medio) {
+    header('Location: /cliente/perfil.php?error=Medio%20de%20pago%20invalido');
+    exit;
+}
+
+try {
+    $pdo->beginTransaction();
+
+    // Registrar el pago
+    $pagoStmt = $pdo->prepare(
+        'INSERT INTO pago (id_abono, id_medio_pago, fecha_pago) VALUES (?, ?, NOW())'
+    );
+    $pagoStmt->execute([$idAbono, $idMedioPago]);
+
+    // Marcar el abono como pagado
+    $updateStmt = $pdo->prepare('UPDATE abono SET pagado = 1 WHERE id = ?');
+    $updateStmt->execute([$idAbono]);
+
+    $pdo->commit();
+
+    header('Location: /cliente/perfil.php?pago=1');
+    exit;
+} catch (PDOException $e) {
+    $pdo->rollBack();
+    header('Location: /cliente/perfil.php?error=Error%20al%20registrar%20pago');
+    exit;
+}


### PR DESCRIPTION
## Resumen
- manejar el pago de abonos en `realizar_pago.php`

## Testing
- `php -l controladores/realizar_pago.php` *(falló: `php` no está instalado)*

------
https://chatgpt.com/codex/tasks/task_e_686b460d352c832b94b811e69e55497e