### PR TITLE
Add payment event table and logging

### DIFF
--- a/alquiler_vehiculos/controladores/realizar_pago.php
+++ b/alquiler_vehiculos/controladores/realizar_pago.php
@@ -60,6 +60,12 @@ try {
     );
     $pagoStmt->execute([$idAbono, $idMedioPago]);
 
+    // Almacenar el evento para auditoría
+    $eventoStmt = $pdo->prepare(
+        'INSERT INTO pago_evento (id_abono, id_medio_pago, id_usuario, fecha_evento) VALUES (?, ?, ?, NOW())'
+    );
+    $eventoStmt->execute([$idAbono, $idMedioPago, $idCliente]);
+
     // Marcar el abono como pagado e indicar el medio utilizado
     $updateStmt = $pdo->prepare(
         'UPDATE Abono_reserva SET estado = "pagado", id_medio_pago = ? WHERE id_abono = ?'

--- a/alquiler_vehiculos/sql/alquiler_vehiculos.sql
+++ b/alquiler_vehiculos/sql/alquiler_vehiculos.sql
@@ -88,6 +88,15 @@ CREATE TABLE pago (
   fecha_pago DATE
 );
 
+-- Registro de los eventos de pago realizados por los clientes
+CREATE TABLE pago_evento (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  id_abono INT,
+  id_medio_pago INT,
+  id_usuario INT,
+  fecha_evento TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
 CREATE TABLE proveedor (
   id_proveedor INT PRIMARY KEY,
   ubicacion VARCHAR(255),


### PR DESCRIPTION
## Summary
- log payment events in new `pago_evento` table
- create the table in the schema

## Testing
- `php -l alquiler_vehiculos/controladores/realizar_pago.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686b4a359030832b9188c9cbb8d66509