### PR TITLE
Add SweetAlert2 confirmations

### DIFF
--- a/alquiler_vehiculos/cliente/secciones/mis_datos.php
+++ b/alquiler_vehiculos/cliente/secciones/mis_datos.php
@@ -88,7 +88,7 @@ if ($idCliente) {
         La fecha de expedición no puede ser posterior a la de vencimiento
     </div>
 
-    <button type="submit" class="btn btn-primary">Actualizar licencia</button>
+    <button type="submit" id="btnActualizarLicencia" class="btn btn-primary">Actualizar licencia</button>
 </form>
 <script>
 document.addEventListener('DOMContentLoaded', function () {
@@ -109,5 +109,41 @@ document.addEventListener('DOMContentLoaded', function () {
             errorDiv.classList.add('d-none');
         }
     });
+});
+</script>
+<script src="https://cdn.jsdelivr.net/npm/sweetalert2@11" defer></script>
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const btnLicencia = document.getElementById('btnActualizarLicencia');
+    const btnPago = document.getElementById('btnConfirmarPago');
+
+    const attachConfirm = function(button, title, text) {
+        if (!button) return;
+        button.addEventListener('click', function (e) {
+            e.preventDefault();
+            const form = button.closest('form');
+            if (!form) return;
+
+            Swal.fire({
+                title: title,
+                text: text,
+                icon: 'question',
+                showCancelButton: true,
+                confirmButtonText: 'Aceptar',
+                cancelButtonText: 'Cancelar'
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    if (typeof form.requestSubmit === 'function') {
+                        form.requestSubmit(button);
+                    } else {
+                        form.submit();
+                    }
+                }
+            });
+        });
+    };
+
+    attachConfirm(btnLicencia, '¿Actualizar licencia?', 'Se guardarán los cambios de la licencia');
+    attachConfirm(btnPago, '¿Confirmar pago?', 'Se procederá con el pago seleccionado');
 });
 </script>


### PR DESCRIPTION
## Summary
- add confirm dialog when updating license info via SweetAlert2
- prepare confirm logic for future payment button

## Testing
- `php -l alquiler_vehiculos/cliente/secciones/mis_datos.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b51941af8832b8b6b5ef22beb72a3