### PR TITLE
Fix PDO usage in validar_login

### DIFF
--- a/alquiler_vehiculos/controladores/validar_login.php
+++ b/alquiler_vehiculos/controladores/validar_login.php
@@ -2,6 +2,9 @@
 session_start();
 require_once '../modelos/conexion.php';
 
+// Obtener instancia de PDO
+$pdo = Conexion::getPDO();
+
 // Validar campos
 if (empty($_POST['correo']) || empty($_POST['contrasena'])) {
     header("Location: ../login.php?error=Completa todos los campos");


### PR DESCRIPTION
## Summary
- instantiate PDO after including the DB connection class

## Testing
- `php -l alquiler_vehiculos/controladores/validar_login.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b725667c4832b88c1b2ee8243e09a