### PR TITLE
Add CRUD logic to PHP models

### DIFF
--- a/alquiler_vehiculos/modelos/alquiler_modelo.php
+++ b/alquiler_vehiculos/modelos/alquiler_modelo.php
@@ -1,3 +1,88 @@
 <?php
-// Placeholder for alquiler_modelo.php
+/**
+ * Modelo para operaciones sobre la tabla `alquiler`.
+ *
+ * Metodos disponibles:
+ * - crear(array $datos): int    Inserta un registro y devuelve el ID generado.
+ * - obtenerPorId(int $id): ?array    Obtiene un alquiler por su ID.
+ * - actualizar(int $id, array $datos): bool    Actualiza los campos indicados.
+ * - eliminar(int $id): bool    Elimina el registro especificado.
+ * - obtenerTodos(): array    Devuelve todos los alquileres.
+ */
 
+require_once 'conexion.php';
+
+class AlquilerModelo
+{
+    /**
+     * Inserta un nuevo alquiler.
+     *
+     * @param array $datos Asociacion columna => valor.
+     * @return int ID generado
+     */
+    public static function crear(array $datos): int
+    {
+        $pdo = Conexion::getPDO();
+        $columnas = array_keys($datos);
+        $placeholders = implode(',', array_fill(0, count($columnas), '?'));
+        $sql = 'INSERT INTO alquiler (' . implode(',', $columnas) . ') VALUES (' . $placeholders . ')';
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute(array_values($datos));
+        return (int) $pdo->lastInsertId();
+    }
+
+    /**
+     * Obtiene un alquiler por ID.
+     */
+    public static function obtenerPorId(int $id): ?array
+    {
+        $pdo = Conexion::getPDO();
+        $stmt = $pdo->prepare('SELECT * FROM alquiler WHERE id = ?');
+        $stmt->execute([$id]);
+        $res = $stmt->fetch();
+        return $res ?: null;
+    }
+
+    /**
+     * Actualiza los campos de un alquiler.
+     */
+    public static function actualizar(int $id, array $datos): bool
+    {
+        if (empty($datos)) {
+            return false;
+        }
+        $pdo = Conexion::getPDO();
+        $sets = [];
+        $params = [];
+        foreach ($datos as $col => $val) {
+            $sets[] = "$col = ?";
+            $params[] = $val;
+        }
+        $params[] = $id;
+        $sql = 'UPDATE alquiler SET ' . implode(',', $sets) . ' WHERE id = ?';
+        $stmt = $pdo->prepare($sql);
+        return $stmt->execute($params);
+    }
+
+    /**
+     * Elimina un alquiler por ID.
+     */
+    public static function eliminar(int $id): bool
+    {
+        $pdo = Conexion::getPDO();
+        $stmt = $pdo->prepare('DELETE FROM alquiler WHERE id = ?');
+        return $stmt->execute([$id]);
+    }
+
+    /**
+     * Devuelve todos los alquileres almacenados.
+     */
+    public static function obtenerTodos(): array
+    {
+        $pdo = Conexion::getPDO();
+        $stmt = $pdo->query('SELECT * FROM alquiler');
+        return $stmt->fetchAll();
+    }
+}
+
+?>

--- a/alquiler_vehiculos/modelos/cliente_modelo.php
+++ b/alquiler_vehiculos/modelos/cliente_modelo.php
@@ -1,3 +1,70 @@
 <?php
-// Placeholder for cliente_modelo.php
+/**
+ * Modelo para la gestión de clientes (tabla `usuario`).
+ *
+ * Métodos disponibles:
+ * - crear(array $datos): int
+ * - obtenerPorId(int $id): ?array
+ * - actualizar(int $id, array $datos): bool
+ * - eliminar(int $id): bool
+ * - obtenerTodos(): array
+ */
 
+require_once 'conexion.php';
+
+class ClienteModelo
+{
+    public static function crear(array $datos): int
+    {
+        $pdo = Conexion::getPDO();
+        $cols = array_keys($datos);
+        $placeholders = implode(',', array_fill(0, count($cols), '?'));
+        $sql = 'INSERT INTO usuario (' . implode(',', $cols) . ') VALUES (' . $placeholders . ')';
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute(array_values($datos));
+        return (int) $pdo->lastInsertId();
+    }
+
+    public static function obtenerPorId(int $id): ?array
+    {
+        $pdo = Conexion::getPDO();
+        $stmt = $pdo->prepare('SELECT * FROM usuario WHERE id = ?');
+        $stmt->execute([$id]);
+        $res = $stmt->fetch();
+        return $res ?: null;
+    }
+
+    public static function actualizar(int $id, array $datos): bool
+    {
+        if (empty($datos)) {
+            return false;
+        }
+        $pdo = Conexion::getPDO();
+        $sets = [];
+        $params = [];
+        foreach ($datos as $col => $val) {
+            $sets[] = "$col = ?";
+            $params[] = $val;
+        }
+        $params[] = $id;
+        $sql = 'UPDATE usuario SET ' . implode(',', $sets) . ' WHERE id = ?';
+        $stmt = $pdo->prepare($sql);
+        return $stmt->execute($params);
+    }
+
+    public static function eliminar(int $id): bool
+    {
+        $pdo = Conexion::getPDO();
+        $stmt = $pdo->prepare('DELETE FROM usuario WHERE id = ?');
+        return $stmt->execute([$id]);
+    }
+
+    public static function obtenerTodos(): array
+    {
+        $pdo = Conexion::getPDO();
+        $stmt = $pdo->query('SELECT * FROM usuario');
+        return $stmt->fetchAll();
+    }
+}
+
+?>

--- a/alquiler_vehiculos/modelos/licencia_modelo.php
+++ b/alquiler_vehiculos/modelos/licencia_modelo.php
@@ -1,3 +1,70 @@
 <?php
-// Placeholder for licencia_modelo.php
+/**
+ * Modelo para la tabla `licencia`.
+ *
+ * Métodos disponibles:
+ * - crear(array $datos): int
+ * - obtenerPorId(int $id): ?array
+ * - actualizar(int $id, array $datos): bool
+ * - eliminar(int $id): bool
+ * - obtenerTodos(): array
+ */
 
+require_once 'conexion.php';
+
+class LicenciaModelo
+{
+    public static function crear(array $datos): int
+    {
+        $pdo = Conexion::getPDO();
+        $cols = array_keys($datos);
+        $placeholders = implode(',', array_fill(0, count($cols), '?'));
+        $sql = 'INSERT INTO licencia (' . implode(',', $cols) . ') VALUES (' . $placeholders . ')';
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute(array_values($datos));
+        return (int) $pdo->lastInsertId();
+    }
+
+    public static function obtenerPorId(int $id): ?array
+    {
+        $pdo = Conexion::getPDO();
+        $stmt = $pdo->prepare('SELECT * FROM licencia WHERE id = ?');
+        $stmt->execute([$id]);
+        $res = $stmt->fetch();
+        return $res ?: null;
+    }
+
+    public static function actualizar(int $id, array $datos): bool
+    {
+        if (empty($datos)) {
+            return false;
+        }
+        $pdo = Conexion::getPDO();
+        $sets = [];
+        $params = [];
+        foreach ($datos as $col => $val) {
+            $sets[] = "$col = ?";
+            $params[] = $val;
+        }
+        $params[] = $id;
+        $sql = 'UPDATE licencia SET ' . implode(',', $sets) . ' WHERE id = ?';
+        $stmt = $pdo->prepare($sql);
+        return $stmt->execute($params);
+    }
+
+    public static function eliminar(int $id): bool
+    {
+        $pdo = Conexion::getPDO();
+        $stmt = $pdo->prepare('DELETE FROM licencia WHERE id = ?');
+        return $stmt->execute([$id]);
+    }
+
+    public static function obtenerTodos(): array
+    {
+        $pdo = Conexion::getPDO();
+        $stmt = $pdo->query('SELECT * FROM licencia');
+        return $stmt->fetchAll();
+    }
+}
+
+?>

--- a/alquiler_vehiculos/modelos/pago_modelo.php
+++ b/alquiler_vehiculos/modelos/pago_modelo.php
@@ -1,3 +1,70 @@
 <?php
-// Placeholder for pago_modelo.php
+/**
+ * Modelo para la tabla `pago`.
+ *
+ * Métodos disponibles:
+ * - crear(array $datos): int
+ * - obtenerPorId(int $id): ?array
+ * - actualizar(int $id, array $datos): bool
+ * - eliminar(int $id): bool
+ * - obtenerTodos(): array
+ */
 
+require_once 'conexion.php';
+
+class PagoModelo
+{
+    public static function crear(array $datos): int
+    {
+        $pdo = Conexion::getPDO();
+        $cols = array_keys($datos);
+        $placeholders = implode(',', array_fill(0, count($cols), '?'));
+        $sql = 'INSERT INTO pago (' . implode(',', $cols) . ') VALUES (' . $placeholders . ')';
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute(array_values($datos));
+        return (int) $pdo->lastInsertId();
+    }
+
+    public static function obtenerPorId(int $id): ?array
+    {
+        $pdo = Conexion::getPDO();
+        $stmt = $pdo->prepare('SELECT * FROM pago WHERE id = ?');
+        $stmt->execute([$id]);
+        $res = $stmt->fetch();
+        return $res ?: null;
+    }
+
+    public static function actualizar(int $id, array $datos): bool
+    {
+        if (empty($datos)) {
+            return false;
+        }
+        $pdo = Conexion::getPDO();
+        $sets = [];
+        $params = [];
+        foreach ($datos as $col => $val) {
+            $sets[] = "$col = ?";
+            $params[] = $val;
+        }
+        $params[] = $id;
+        $sql = 'UPDATE pago SET ' . implode(',', $sets) . ' WHERE id = ?';
+        $stmt = $pdo->prepare($sql);
+        return $stmt->execute($params);
+    }
+
+    public static function eliminar(int $id): bool
+    {
+        $pdo = Conexion::getPDO();
+        $stmt = $pdo->prepare('DELETE FROM pago WHERE id = ?');
+        return $stmt->execute([$id]);
+    }
+
+    public static function obtenerTodos(): array
+    {
+        $pdo = Conexion::getPDO();
+        $stmt = $pdo->query('SELECT * FROM pago');
+        return $stmt->fetchAll();
+    }
+}
+
+?>


### PR DESCRIPTION
## Summary
- implement CRUD methods in model classes
- document all available methods

## Testing
- `php -l alquiler_vehiculos/modelos/alquiler_modelo.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b7257aa6c832b94c68f2b69cb86d5