### PR TITLE
Add CSRF validation for login

### DIFF
--- a/alquiler_vehiculos/controladores/validar_login.php
+++ b/alquiler_vehiculos/controladores/validar_login.php
@@ -1,9 +1,15 @@
 <?php
 session_start();
 require_once '../modelos/conexion.php';
+require_once '../includes/csrf.php';
 
 // Obtener instancia de PDO
 $pdo = Conexion::getPDO();
+
+if (!validarToken($_POST['csrf_token'] ?? '')) {
+    header('Location: ../login.php?error=Acceso%20no%20autorizado');
+    exit();
+}
 
 // Validar campos
 if (empty($_POST['correo']) || empty($_POST['contrasena'])) {

--- a/alquiler_vehiculos/login.php
+++ b/alquiler_vehiculos/login.php
@@ -4,6 +4,7 @@ ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 
 session_start();
+require_once 'includes/csrf.php';
 $mensaje = $_GET['error'] ?? '';
 ?>
 
@@ -28,6 +29,7 @@ $mensaje = $_GET['error'] ?? '';
           <?php endif; ?>
 
           <form method="POST" action="controladores/validar_login.php">
+            <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(generarToken()); ?>">
             <div class="mb-3">
               <label for="correo" class="form-label">Correo electrónico</label>
               <input type="email" class="form-control" id="correo" name="correo" required>


### PR DESCRIPTION
## Summary
- generate CSRF token on the login form
- validate CSRF token before authenticating users

## Testing
- `php -l alquiler_vehiculos/login.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686b7816859c832b9e8a390e1d383831