### PR TITLE
Fix payment update query

### DIFF
--- a/alquiler_vehiculos/controladores/realizar_pago.php
+++ b/alquiler_vehiculos/controladores/realizar_pago.php
@@ -68,7 +68,7 @@ try {
 
     // Marcar el abono como pagado e indicar el medio utilizado
     $updateStmt = $pdo->prepare(
-        'UPDATE Abono_reserva SET estado = "pagado", id_medio_pago = ? WHERE id_abono = ?'
+        'UPDATE Abono_reserva SET estado = "pagado", id_medio_pago = ? WHERE id = ?'
     );
     $updateStmt->execute([$idMedioPago, $idAbono]);
 


### PR DESCRIPTION
## Summary
- use the correct `id` primary key when updating `Abono_reserva`

## Testing
- `php -l alquiler_vehiculos/controladores/realizar_pago.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b781786f8832b8c821dc150d7b82d