### PR TITLE
Fix mis_datos query by id_usuario

### DIFF
--- a/alquiler_vehiculos/cliente/secciones/mis_datos.php
+++ b/alquiler_vehiculos/cliente/secciones/mis_datos.php
@@ -13,7 +13,11 @@ $licencia = [];
 
 if ($idCliente) {
     // Datos personales del usuario
-    $stmt = $pdo->prepare('SELECT numero_identificacion, CONCAT(nombre, " ", apellido) AS nombre_completo, telefono, email, direccion FROM usuario WHERE id_cliente = ?');
+    $stmt = $pdo->prepare(
+        'SELECT numero_identificacion, CONCAT(nombre, " ", apellido) AS nombre_completo,
+        telefono, email, direccion
+        FROM usuario WHERE id_usuario = ?'
+    );
     $stmt->execute([$idCliente]);
     $cliente = $stmt->fetch();
 


### PR DESCRIPTION
## Summary
- filter personal data query by `id_usuario`
- keep using `$_SESSION['id_cliente']` parameter

## Testing
- `php -l alquiler_vehiculos/cliente/secciones/mis_datos.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686baed9d314832b9406c1e80f923313