### PR TITLE
Fix login verification and messages

### DIFF
--- a/alquiler_vehiculos/controladores/validar_login.php
+++ b/alquiler_vehiculos/controladores/validar_login.php
@@ -1,10 +1,15 @@
 <?php
 session_start();
-require_once '../modelos/conexion.php';
-require_once '../includes/csrf.php';
+require_once __DIR__ . '/../modelos/conexion.php';
+require_once __DIR__ . '/../includes/csrf.php';
 
-// Obtener instancia de PDO
-$pdo = Conexion::getPDO();
+// Obtener instancia de PDO con manejo de errores
+try {
+    $pdo = Conexion::getPDO();
+} catch (PDOException $e) {
+    header('Location: ../login.php?error=Error%20de%20conexion');
+    exit();
+}
 
 if (!validarToken($_POST['csrf_token'] ?? '')) {
     header('Location: ../login.php?error=Acceso%20no%20autorizado');
@@ -17,25 +22,31 @@ if (empty($_POST['correo']) || empty($_POST['contrasena'])) {
     exit();
 }
 
-$usuarioInput = $_POST['correo'];
-$contrasena = $_POST['contrasena'];
+
+$usuarioInput = trim($_POST['correo']);
+$contrasena    = $_POST['contrasena'];
 
 // Buscar usuario y obtener rol real
-$sql = "SELECT u.id_usuario, u.contrasena, u.id_cliente, r.nombre AS rol
-        FROM usuario u
-        INNER JOIN rol r ON u.id_rol = r.id_rol
-        WHERE u.usuario = ?";
-$stmt = $pdo->prepare($sql);
-$stmt->execute([$usuarioInput]);
-$usuario = $stmt->fetch(PDO::FETCH_ASSOC);
+try {
+    $sql = "SELECT u.id_usuario, u.contrasena, r.nombre AS rol
+            FROM usuario u
+            INNER JOIN rol r ON u.id_rol = r.id_rol
+            WHERE u.email = ?";
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute([$usuarioInput]);
+    $usuario = $stmt->fetch(PDO::FETCH_ASSOC);
+} catch (PDOException $e) {
+    header('Location: ../login.php?error=Error%20al%20consultar%20usuario');
+    exit();
+}
 
 if ($usuario && password_verify($contrasena, $usuario['contrasena'])) {
     $_SESSION['id_usuario'] = $usuario['id_usuario'];
     $_SESSION['rol'] = $usuario['rol'];
     
     if ($usuario['rol'] === 'cliente') {
-        $_SESSION['id_cliente'] = $usuario['id_cliente'];
-        header("Location: ../cliente/perfil.php");
+        $_SESSION['id_cliente'] = $usuario['id_usuario'];
+        header('Location: ../cliente/perfil.php');
     } else {
         // Para casos donde otros roles aún no se usan
         header("Location: ../login.php?error=Rol no disponible en esta versión");

--- a/alquiler_vehiculos/login.php
+++ b/alquiler_vehiculos/login.php
@@ -4,8 +4,10 @@ ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 
 session_start();
-require_once 'includes/csrf.php';
-$mensaje = $_GET['error'] ?? '';
+require_once __DIR__ . '/includes/csrf.php';
+
+$mensajeError = $_GET['error'] ?? '';
+$mensajeInfo  = $_GET['mensaje'] ?? '';
 ?>
 
 <!DOCTYPE html>
@@ -24,8 +26,10 @@ $mensaje = $_GET['error'] ?? '';
         <div class="card-body">
           <h3 class="text-center mb-4">Iniciar Sesión</h3>
           
-          <?php if ($mensaje): ?>
-            <div class="alert alert-danger"><?php echo htmlspecialchars($mensaje); ?></div>
+          <?php if ($mensajeError): ?>
+            <div class="alert alert-danger"><?php echo htmlspecialchars($mensajeError); ?></div>
+          <?php elseif ($mensajeInfo): ?>
+            <div class="alert alert-success"><?php echo htmlspecialchars($mensajeInfo); ?></div>
           <?php endif; ?>
 
           <form method="POST" action="controladores/validar_login.php">


### PR DESCRIPTION
## Summary
- improve DB connection error handling in `validar_login.php`
- authenticate by email and set client session correctly
- show error or success alerts in `login.php`

## Testing
- `php -l alquiler_vehiculos/controladores/validar_login.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686bb40f95d4832b8c2037ec1975a3b4