### PR TITLE
Implement password verification for login

### DIFF
--- a/cliente/modelos/cliente_modelo.php
+++ b/cliente/modelos/cliente_modelo.php
@@ -1,3 +1,25 @@
 <?php
-// Placeholder for cliente_modelo.php
+require_once __DIR__ . '/../../config/conexion.php';
 
+class ClienteModelo
+{
+    /**
+     * Verifica las credenciales de un usuario segun su correo.
+     * Devuelve el arreglo con los datos del usuario y el origen
+     * de la base de datos si la contraseña coincide.
+     */
+    public static function verificarCredenciales(string $correo, string $clave): ?array
+    {
+        $resultado = buscarUsuarioPorEmail($correo);
+        if (!$resultado) {
+            return null;
+        }
+
+        $hash = $resultado['usuario']['hashed_password'] ?? null;
+        if ($hash && password_verify($clave, $hash)) {
+            return $resultado;
+        }
+
+        return null;
+    }
+}

--- a/public/login.php
+++ b/public/login.php
@@ -1,5 +1,6 @@
 <?php
 session_start();
+require_once __DIR__ . '/../cliente/modelos/cliente_modelo.php';
 
 function buscarUsuarioPorEmail($email) {
     $servidores = [
@@ -29,7 +30,7 @@ function buscarUsuarioPorEmail($email) {
                 ]
             );
 
-            $stmt = $pdo->prepare("SELECT * FROM usuario WHERE email = ?");
+            $stmt = $pdo->prepare("SELECT u.*, u.password AS hashed_password FROM usuario u WHERE u.email = ?");
             $stmt->execute([$email]);
             $usuario = $stmt->fetch(PDO::FETCH_ASSOC);
 
@@ -48,8 +49,9 @@ function buscarUsuarioPorEmail($email) {
 
 if ($_SERVER['REQUEST_METHOD'] == 'POST') {
     $email = $_POST['email'];
+    $clave = $_POST['password'];
 
-    $resultado = buscarUsuarioPorEmail($email);
+    $resultado = ClienteModelo::verificarCredenciales($email, $clave);
 
     if ($resultado) {
         $_SESSION['usuario'] = $resultado['usuario'];
@@ -62,10 +64,9 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
             default: echo "Tipo de usuario desconocido."; exit;
         }
 
-
         exit;
     } else {
-        $error = "Correo no encontrado.";
+        $error = "Credenciales incorrectas.";
     }
 }
 ?>
@@ -85,6 +86,10 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
         <div class="mb-3">
             <label for="email">Correo:</label>
             <input type="email" name="email" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label for="password">Contraseña:</label>
+            <input type="password" name="password" class="form-control" required>
         </div>
         <button type="submit" class="btn btn-primary">Ingresar</button>
     </form>


### PR DESCRIPTION
## Summary
- require customer model in login page
- fetch the hashed password in `buscarUsuarioPorEmail`
- add password input on login form
- verify credentials via `ClienteModelo::verificarCredenciales`

## Testing
- `php -l public/login.php`
- `php -l cliente/modelos/cliente_modelo.php`


------
https://chatgpt.com/codex/tasks/task_e_686c279799dc832ba300231f0f1fa371